### PR TITLE
Remove leading space from keywords.txt identifier token

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,44 +5,44 @@
 #######################################
 # Library (KEYWORD3)
 #######################################
-sfxAntenna	            KEYWORD3
+sfxAntenna	KEYWORD3
 
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-sigFoxModeE	 KEYWORD1
+sigFoxModeE	KEYWORD1
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-setSfxConfigurationMode	        KEYWORD2
-readSerialNumber	      KEYWORD2
-getLastReceivedMessage	   KEYWORD2
-getSfxError	   KEYWORD2
-setSfxDataMode	   KEYWORD2
-sfxSendData	   KEYWORD2
-sfxSendDataAck	   KEYWORD2
-sfxDataAcknoledge	   KEYWORD2
-sfxSendConf	   KEYWORD2
-sfxSendKeep	   KEYWORD2
-hasSfxAnswer	   KEYWORD2
-getSfxMode	   KEYWORD2
-sfxSendBtlPage	   KEYWORD2
-setSfxSleepMode	   KEYWORD2
-getSfxSleepMode	   KEYWORD2
-setSfxFactoryReset	   KEYWORD2
-readSwVersion	   KEYWORD2
-readSN	   KEYWORD2
-enterBtl	   KEYWORD2
-sfxSendBtlPage	   KEYWORD2
-getBaudRate	   KEYWORD2
-setBaudRate	   KEYWORD2
+setSfxConfigurationMode	KEYWORD2
+readSerialNumber	KEYWORD2
+getLastReceivedMessage	KEYWORD2
+getSfxError	KEYWORD2
+setSfxDataMode	KEYWORD2
+sfxSendData	KEYWORD2
+sfxSendDataAck	KEYWORD2
+sfxDataAcknoledge	KEYWORD2
+sfxSendConf	KEYWORD2
+sfxSendKeep	KEYWORD2
+hasSfxAnswer	KEYWORD2
+getSfxMode	KEYWORD2
+sfxSendBtlPage	KEYWORD2
+setSfxSleepMode	KEYWORD2
+getSfxSleepMode	KEYWORD2
+setSfxFactoryReset	KEYWORD2
+readSwVersion	KEYWORD2
+readSN	KEYWORD2
+enterBtl	KEYWORD2
+sfxSendBtlPage	KEYWORD2
+getBaudRate	KEYWORD2
+setBaudRate	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-sfxConfigurationMode	 LITERAL1
-sfxEnterDataMode	     LITERAL1
-sfxDataMode	         LITERAL1
+sfxConfigurationMode	LITERAL1
+sfxEnterDataMode	LITERAL1
+sfxDataMode	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3, LITERAL2).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords